### PR TITLE
Issue 28 - bugfix to support heatmap downsampling in the presence of missing values

### DIFF
--- a/man/downsample_heatmap.Rd
+++ b/man/downsample_heatmap.Rd
@@ -4,7 +4,7 @@
 \alias{downsample_heatmap}
 \title{Downsample Heatmap}
 \usage{
-downsample_heatmap(tidy_data, value_var, max_display_features = 1000)
+downsample_heatmap(tidy_data, value_var, design, max_display_features = 1000)
 }
 \arguments{
 \item{tidy_data}{The data datable from a \code{tidy_omic} object containing
@@ -12,6 +12,8 @@ ordered feature and sample primary keys defined by ordered_featureId
 and ordered_sampleId.}
 
 \item{value_var}{which variable in "measurements" to use for quantification.}
+
+\item{design}{a list summarizing the design of the tidy dataset}
 
 \item{max_display_features}{aggregate and downsample distinct feature to
 this number to speed to up heatmap rendering.}

--- a/tests/testthat/test-downsampling.R
+++ b/tests/testthat/test-downsampling.R
@@ -7,7 +7,11 @@ test_that("downsampling features (for creating a heatmap works)", {
       ordered_featureId = factor(name, levels = unique(name)),
       ordered_sampleId = factor(sample, levels = unique(sample))
       ) %>%
-    downsample_heatmap(value_var = "expression", 100)
+    downsample_heatmap(
+      value_var = "expression",
+      design = brauer_2008_tidy$design,
+      max_display_features = 100
+      )
 
   expect_equal(nrow(downsampled_df), 3600)
   expect_equal(length(unique(downsampled_df$name)), 100)


### PR DESCRIPTION
updated downsample_heatmap to handle missing values in the value_variable; feature attributes are collapsed to avoid inconsistencies across samples for the same feature. closes #28 