### PR TITLE
Issue 33 - adding PCs to datasets with non-character sample primary keys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: romic
 Type: Package
 Title: R for High-Dimensional Omic Data
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c(
     person(
       given = "Sean",

--- a/R/data_classes.R
+++ b/R/data_classes.R
@@ -141,8 +141,7 @@ create_tidy_omic <- function(df,
 #' @param fast_check if TRUE then skip some checks which are slow and that are
 #' generally only needed when a \code{tomic} object is first created.
 #'
-#' @return Error and warning messages are printed and the input tidy_omic
-#' object is returned
+#' @return 0 invisibly
 check_tidy_omic <- function(tidy_omic, fast_check = TRUE) {
   checkmate::assertClass(tidy_omic, "tidy_omic")
   checkmate::assertLogical(fast_check, len = 1)
@@ -436,8 +435,7 @@ create_triple_omic <- function(measurement_df,
 #'   \code{\link{create_triple_omic}}
 #' @inheritParams check_tidy_omic
 #'
-#' @return Error and warning messages are printed and the input tidy_omic
-#'   object is returned
+#' @return 0 invisibly
 check_triple_omic <- function(triple_omic, fast_check = TRUE) {
   checkmate::assertClass(triple_omic, "triple_omic")
   checkmate::assertLogical(fast_check, len = 1)
@@ -541,6 +539,8 @@ check_triple_omic <- function(triple_omic, fast_check = TRUE) {
       ))
     }
   }
+
+  return(invisible(0))
 }
 
 #' Triple Omic to Tidy Omic

--- a/R/dim_reduction.R
+++ b/R/dim_reduction.R
@@ -65,12 +65,19 @@ add_pca_loadings <- function(
   pc_loadings <- pc_loadings %>%
     as.data.frame() %>%
     dplyr::as_tibble() %>%
-    dplyr::mutate(!!rlang::sym(sample_pk) := colnames(omic_matrix))
+    dplyr::mutate(
+      !!rlang::sym(sample_pk) := colnames(omic_matrix),
+      # convert the PK to the same class as the original primary key
+      !!rlang::sym(sample_pk) := coerce_to_classes(
+        !!rlang::sym(sample_pk),
+        triple_omic$samples[[sample_pk]]
+        )
+      )
 
   triple_omic$samples <- triple_omic$samples %>%
     # drop existing PCs
     dplyr::select_at(vars(!dplyr::starts_with("PC"))) %>%
-    # add new PCs
+    # create a copy of the primary key to join on
     dplyr::left_join(pc_loadings, by = sample_pk)
 
   triple_omic$design$samples <- triple_omic$design$samples %>%

--- a/man/check_tidy_omic.Rd
+++ b/man/check_tidy_omic.Rd
@@ -14,8 +14,7 @@ check_tidy_omic(tidy_omic, fast_check = TRUE)
 generally only needed when a \code{tomic} object is first created.}
 }
 \value{
-Error and warning messages are printed and the input tidy_omic
-object is returned
+0 invisibly
 }
 \description{
 Check a tidy omic dataset for consistency between the data and design and

--- a/man/check_triple_omic.Rd
+++ b/man/check_triple_omic.Rd
@@ -14,8 +14,7 @@ check_triple_omic(triple_omic, fast_check = TRUE)
 generally only needed when a \code{tomic} object is first created.}
 }
 \value{
-Error and warning messages are printed and the input tidy_omic
-  object is returned
+0 invisibly
 }
 \description{
 Check a triple omic dataset for consistency between the data and design and

--- a/tests/testthat/test-dim_reduction.R
+++ b/tests/testthat/test-dim_reduction.R
@@ -1,31 +1,28 @@
 test_that("Removing missing values works", {
 
   # drop_features
-  expect_equal(
-    nrow(remove_missing_values(
-      brauer_2008_triple,
-      missing_val_method = "drop_features"
-    )$features),
-    460
-  )
+  invisible(capture.output(n_features <- nrow(remove_missing_values(
+    brauer_2008_triple,
+    missing_val_method = "drop_features"
+  )$features)))
+  expect_equal(n_features, 460)
 
   # drop_samples with no missing samples should behave like drop_features
-  expect_equal(
-    nrow(remove_missing_values(
-      brauer_2008_triple,
-      missing_val_method = "drop_samples"
-    )$features),
-    460
-  )
+  invisible(capture.output(n_features <- nrow(remove_missing_values(
+    brauer_2008_triple,
+    missing_val_method = "drop_samples"
+  )$features)))
+  expect_equal(n_features, 460)
 
   brauer_missing_samples <- brauer_2008_triple
   brauer_missing_samples$measurements$expression[
     brauer_missing_samples$measurements$sample %in% c("G0.05", "G0.1")
   ] <- NA
-  filtered_brauer <- remove_missing_values(
+
+  invisible(capture.output(filtered_brauer <- remove_missing_values(
     brauer_missing_samples,
     missing_val_method = "drop_samples"
-  )
+  )))
 
   expect_equal(nrow(filtered_brauer$samples), 34)
   expect_equal(nrow(filtered_brauer$measurements), 15674)

--- a/tests/testthat/test-factor_pks.R
+++ b/tests/testthat/test-factor_pks.R
@@ -1,0 +1,39 @@
+library(dplyr)
+
+test_that("Factor primary keys are preserved when converting from a tidy to a triple", {
+  tidy <- tidyr:::expand_grid(
+    features = letters,
+    samples = LETTERS
+  ) %>%
+    dplyr::mutate(
+      features = factor(features, levels = letters),
+      samples = factor(samples, levels = LETTERS),
+      measurement = 1
+    ) %>%
+    create_tidy_omic(feature_pk = "features", sample_pk = "samples")
+
+  triple_from_tidy <- tomic_to(tidy, "triple_omic")
+  triple_from_tidy_check_status <- romic::check_tomic(triple_from_tidy, fast_check = FALSE)
+  expect_equal(triple_from_tidy_check_status, 0)
+
+  tidy_with_pcs <- add_pca_loadings(tidy)
+  expect_true(sum(stringr::str_detect(colnames(tidy_with_pcs$data), "^PC")) > 1)
+})
+
+test_that("Numeric primary keys are preserved when converting from a tidy to a triple", {
+  tidy <- tidyr:::expand_grid(
+    features = 1:10,
+    samples = 1:10
+  ) %>%
+    dplyr::mutate(
+      measurement = 1
+    ) %>%
+    create_tidy_omic(feature_pk = "features", sample_pk = "samples")
+
+  triple_from_tidy <- tomic_to(tidy, "triple_omic")
+  triple_from_tidy_check_status <- check_tomic(triple_from_tidy, fast_check = FALSE)
+  expect_equal(triple_from_tidy_check_status, 0)
+
+  tidy_with_pcs <- add_pca_loadings(tidy)
+  expect_true(sum(stringr::str_detect(colnames(tidy_with_pcs$data), "^PC")) > 1)
+})

--- a/tests/testthat/test-triple_omic.R
+++ b/tests/testthat/test-triple_omic.R
@@ -1,11 +1,11 @@
 library(dplyr)
 
 test_that("Updating triple retains cohesiveness", {
-  broken_brauer <- romic::brauer_2008_triple
+  broken_brauer <- brauer_2008_triple
   broken_brauer$features <- broken_brauer$features %>% mutate(foo = "bar")
   expect_error(check_tomic(broken_brauer), "permutation")
 
-  broken_brauer <- romic::brauer_2008_triple
+  broken_brauer <- brauer_2008_triple
   broken_brauer$features$name <- factor(broken_brauer$features$name)
   expect_error(check_tomic(broken_brauer), "classes")
 })


### PR DESCRIPTION
When finding PCs using SVD we need to operate on a matrix where feature and sample keys are coerced to character. Joining on back to the original samples table resulted in coercing of the primary key to a character and the resulting mis-matched classes bug. I used the existing coerce_to_classes() to retain the sample primary key's original class