### PR TITLE
Add link to DESCRIPTION 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,8 @@ Suggests:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
+URL: https://calico.github.io/romic/, https://github.com/calico/romic
+BugReports: https://github.com/calico/romic/issues
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Config/testthat/edition: 3


### PR DESCRIPTION
to make the repo and website easier to discover.

You may consider adding the website link in the About page as well on the Github homepage.
![image](https://github.com/calico/romic/assets/52606734/da413351-fab7-4da5-bfc1-6f725c4124e3)
